### PR TITLE
Structured commit message and Changelog generation

### DIFF
--- a/.changelogrc
+++ b/.changelogrc
@@ -1,0 +1,50 @@
+{
+    "app_name": "Babble",
+    "logo": "https://babbleio.readthedocs.io/en/latest/_images/babblelogo.png",
+    "intro": "Babble consensus engine",
+    "branch" : "",
+    "repo_url": "",
+    "file": "CHANGELOG.md",
+    "sections": [
+        {
+            "title": "Bug Fixes",
+            "grep": "^fix"
+        },
+        {
+            "title": "Features",
+            "grep": "^feat"
+        },
+        {
+            "title": "Documentation",
+            "grep": "^docs"
+        },
+        {
+            "title": "Breaking changes",
+            "grep": "BREAKING"
+        },
+        {
+            "title": "Refactor",
+            "grep": "^refactor"
+        },
+        {
+            "title": "Style",
+            "grep": "^style"
+        },
+        {
+            "title": "Test",
+            "grep": "^test"
+        },
+        {
+            "title": "Chore",
+            "grep": "^chore"
+        },
+        {
+            "title": "Branchs merged",
+            "grep": "^Merge branch"
+        },
+        {
+            "title" : "Pull requests merged",
+            "grep": "^Merge pull request"
+        }
+    ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,28 +1,45 @@
-## UNRELEASED
+<img width="300px" src="https://babbleio.readthedocs.io/en/latest/_images/babblelogo.png" />
 
-SECURITY:
+# Babble
 
-FEATURES:
+_Babble consensus engine_
 
-IMPROVEMENTS:
+## v0.3.0 ( Tue Sep 25 2018 00:20:48 GMT+0200 (Central European Summer Time) )
 
-BUG FIXES:
 
-## v0.3.0 (September 4, 2018)
+## Features
 
-FEATURES:
+  - **changelog**
+    - Add changelog generation script from last version tag
+  ([a5b1a95e](https://github.com/mosaicnetworks/babble/commit/a5b1a95e8cdb4651d7e1e28cef98b81026d52ee9))
 
-* hashgraph: Replaced Leemon Baird's original "Fair" ordering method with 
-Lamport timestamps.
-* hashgraph: Introduced the concept of Frames and Roots to enable initializing a
-hashgraph from a "non-zero" state.
-* node: Added FastSync protocol to enable nodes to catch up with other nodes 
-without downloading the entire hashgraph. 
-* proxy: Introduce Snapshot/Restore functionality.
+  - **commit_message**
+    - Enforce a structured commit_message. Add 'make hook' to setup git hook
+  ([b2e1eec0](https://github.com/mosaicnetworks/babble/commit/b2e1eec06063bb509e8c298195a1229578cab836))
 
-IMPROVEMENTS:
 
-* hashgraph: Refactored the consensus methods around the concept of Frames.
-* hashgraph: Removed special case for "initial" Events, and make use of Roots 
-instead. 
-* docs: Added sections on Babble and FastSync.
+
+
+## Branchs merged
+  - Merge branch 'develop' into peers_mutex
+  ([c56e77b5](https://github.com/mosaicnetworks/babble/commit/c56e77b57f35121b0038c16740ee6a224d83cbb6))
+
+
+
+
+## Pull requests merged
+  - Merge pull request #45 from mosaicnetworks/peers_mutex
+  ([bdf9df5c](https://github.com/mosaicnetworks/babble/commit/bdf9df5c4ccaf3ab2f668c6ec2be18612f374a3f))
+  - Merge pull request #46 from mosaicnetworks/update_badger
+  ([4603fa49](https://github.com/mosaicnetworks/babble/commit/4603fa4979654c5bae7efd111f1177844a8688c4))
+  - Merge pull request #36 from mosaicnetworks/tests_factor
+  ([f7442245](https://github.com/mosaicnetworks/babble/commit/f7442245c417f6702f02c20464b6660ba86209da))
+  - Merge pull request #34 from mosaicnetworks/hashed_peers_ids
+  ([2ddf4563](https://github.com/mosaicnetworks/babble/commit/2ddf4563e7087502fd56d19db301e50fd2e9bac0))
+
+
+
+
+
+---
+<sub><sup>*Generated with [git-changelog](https://github.com/rafinskipg/git-changelog). If you have any problems or suggestions, create an issue.* :) **Thanks** </sub></sup>

--- a/CHANGELOG_old.md
+++ b/CHANGELOG_old.md
@@ -1,0 +1,28 @@
+## UNRELEASED
+
+SECURITY:
+
+FEATURES:
+
+IMPROVEMENTS:
+
+BUG FIXES:
+
+## v0.3.0 (September 4, 2018)
+
+FEATURES:
+
+* hashgraph: Replaced Leemon Baird's original "Fair" ordering method with 
+Lamport timestamps.
+* hashgraph: Introduced the concept of Frames and Roots to enable initializing a
+hashgraph from a "non-zero" state.
+* node: Added FastSync protocol to enable nodes to catch up with other nodes 
+without downloading the entire hashgraph. 
+* proxy: Introduce Snapshot/Restore functionality.
+
+IMPROVEMENTS:
+
+* hashgraph: Refactored the consensus methods around the concept of Frames.
+* hashgraph: Removed special case for "initial" Events, and make use of Roots 
+instead. 
+* docs: Added sections on Babble and FastSync.

--- a/makefile
+++ b/makefile
@@ -23,6 +23,9 @@ dist:
 hook:
 	sh -c "'$(CURDIR)/scripts/git_hook.sh'"
 
+changelog:
+	sh -c "'$(CURDIR)/scripts/changelog.sh'"
+
 test:
 	glide novendor | xargs go test
 

--- a/makefile
+++ b/makefile
@@ -5,7 +5,7 @@ vendor:
 	glide install
 
 # install compiles and places the binary in GOPATH/bin
-install: 
+install:
 	go install --ldflags '-extldflags "-static"' \
 		--ldflags "-X github.com/mosaicnetworks/babble/version.GitCommit=`git rev-parse HEAD`" \
 		./cmd/babble
@@ -20,8 +20,10 @@ build:
 dist:
 	@BUILD_TAGS='$(BUILD_TAGS)' sh -c "'$(CURDIR)/scripts/dist.sh'"
 
-test: 
+hook:
+	sh -c "'$(CURDIR)/scripts/git_hook.sh'"
+
+test:
 	glide novendor | xargs go test
 
 .PHONY: vendor install build dist test
-	

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+BRANCH=$1
+
+git-changelog -b $BRANCH -t `git describe --abbrev=0`

--- a/scripts/commit-msg
+++ b/scripts/commit-msg
@@ -1,0 +1,8 @@
+COMMIT_REGEX='^(v?[0-9]+\.[0-9]+\.[0-9]+|Merge.*|(fix|feat|chores)\((\w|\-|\|){3,20}\): ((\w|\-| |&|,|.){5,80})(\s|\w){0,50})$'
+
+if ! grep -iqE "$COMMIT_REGEX" "$1"
+then
+	echo "ERROR: Bad commit message: $1.\n Exemple: 'feat(api): new commit system'"
+
+	exit 1
+fi

--- a/scripts/git_hook.sh
+++ b/scripts/git_hook.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [[ -d "./.git/hooks" ]]
+then
+  cp ./scripts/commit-msg ./.git/hooks
+
+  chmod +x ./.git/hooks/commit-msg
+else
+  echo "Not in a repo or not launched from repo root."
+fi


### PR DESCRIPTION
Forces to have a commit message like the following

`feat(scope): Message`
`fix(proxy): No more debug `
`chores(fs): Moved the folder X to Y`

This enforce the first line only. Then the following lines can have any form and will still be included into the generated CHANGELOG

This feature needs `git-changelog` available from the `$PATH`

To install it: `npm install -g git-changelog`