### PR TITLE
fix(node): Peer selector fail with only 2 participants

### DIFF
--- a/node/peer_selector.go
+++ b/node/peer_selector.go
@@ -38,11 +38,18 @@ func (ps *RandomPeerSelector) UpdateLast(peer string) {
 
 func (ps *RandomPeerSelector) Next() *peers.Peer {
 	selectablePeers := ps.peers.ToPeerSlice()
+
 	if len(selectablePeers) > 1 {
 		_, selectablePeers = peers.ExcludePeer(selectablePeers, ps.localAddr)
-		_, selectablePeers = peers.ExcludePeer(selectablePeers, ps.last)
+
+		if len(selectablePeers) > 1 {
+			_, selectablePeers = peers.ExcludePeer(selectablePeers, ps.last)
+		}
 	}
+
 	i := rand.Intn(len(selectablePeers))
+
 	peer := selectablePeers[i]
+
 	return peer
 }


### PR DESCRIPTION
When only two participants, the peer_selector was emptying its peer_list trying to find a valid random peer, causing a panic error on the call to `rand.Intn(0)`