### PR TITLE
Replace hg CommitCh with Callback.

### DIFF
--- a/src/hashgraph/hashgraph_test.go
+++ b/src/hashgraph/hashgraph_test.go
@@ -75,6 +75,10 @@ func testLogger(t testing.TB) *logrus.Entry {
 	return common.NewTestLogger(t).WithField("id", "test")
 }
 
+func testCommitCallback(block *Block) error {
+	return nil
+}
+
 /* Initialisation functions */
 
 func initHashgraphNodes(n int) ([]TestNode, map[string]string, *[]*Event, *peers.PeerSet) {
@@ -122,7 +126,7 @@ func createHashgraph(db bool, orderedEvents *[]*Event, peerSet *peers.PeerSet, l
 		store = NewInmemStore(peerSet, cacheSize)
 	}
 
-	hashgraph := NewHashgraph(peerSet, store, nil, logger)
+	hashgraph := NewHashgraph(peerSet, store, testCommitCallback, logger)
 
 	for i, ev := range *orderedEvents {
 		if err := hashgraph.InsertEvent(ev, true); err != nil {
@@ -355,7 +359,7 @@ func TestFork(t *testing.T) {
 	peerSet := peers.NewPeerSet(pirs)
 
 	store := NewInmemStore(peerSet, cacheSize)
-	hashgraph := NewHashgraph(peerSet, store, nil, testLogger(t))
+	hashgraph := NewHashgraph(peerSet, store, testCommitCallback, testLogger(t))
 
 	for i, node := range nodes {
 		event := NewEvent(nil, nil, nil, []string{"", ""}, node.Pub, 0)
@@ -977,7 +981,7 @@ func initBlockHashgraph(t *testing.T) (*Hashgraph, []TestNode, map[string]string
 		nodes[i].signAndAddEvent(event, fmt.Sprintf("e%d", i), index, orderedEvents)
 	}
 
-	hashgraph := NewHashgraph(peerSet, NewInmemStore(peerSet, cacheSize), nil, testLogger(t))
+	hashgraph := NewHashgraph(peerSet, NewInmemStore(peerSet, cacheSize), testCommitCallback, testLogger(t))
 
 	//create a block and signatures manually
 	block := NewBlock(0, 1, []byte("framehash"), peerSet.Peers, [][]byte{[]byte("block tx")})
@@ -1820,7 +1824,7 @@ func TestResetFromFrame(t *testing.T) {
 
 	h2 := NewHashgraph(peerSet,
 		NewInmemStore(peerSet, cacheSize),
-		nil,
+		testCommitCallback,
 		testLogger(t))
 	err = h2.Reset(block, unmarshalledFrame)
 	if err != nil {
@@ -2019,7 +2023,7 @@ func TestBootstrap(t *testing.T) {
 	}
 	nh := NewHashgraph(peerSet,
 		recycledStore,
-		nil,
+		testCommitCallback,
 		logrus.New().WithField("id", "bootstrapped"))
 	err = nh.Bootstrap()
 	if err != nil {
@@ -2452,7 +2456,7 @@ func TestFunkyHashgraphReset(t *testing.T) {
 
 		h2 := NewHashgraph(peerSet,
 			NewInmemStore(peerSet, cacheSize),
-			nil,
+			testCommitCallback,
 			testLogger(t))
 		err = h2.Reset(block, unmarshalledFrame)
 		if err != nil {
@@ -2763,7 +2767,7 @@ func TestSparseHashgraphReset(t *testing.T) {
 
 		h2 := NewHashgraph(peerSet,
 			NewInmemStore(peerSet, cacheSize),
-			nil,
+			testCommitCallback,
 			testLogger(t))
 		err = h2.Reset(block, unmarshalledFrame)
 		if err != nil {

--- a/src/node/core.go
+++ b/src/node/core.go
@@ -36,8 +36,8 @@ func NewCore(
 	key *ecdsa.PrivateKey,
 	peers *peers.PeerSet,
 	store hg.Store,
-	commitCh chan hg.Block,
-	logger *logrus.Logger) Core {
+	commitCallback hg.CommitCallback,
+	logger *logrus.Logger) *Core {
 
 	if logger == nil {
 		logger = logrus.New()
@@ -45,10 +45,10 @@ func NewCore(
 	}
 	logEntry := logger.WithField("id", id)
 
-	core := Core{
+	core := &Core{
 		id:                      id,
 		key:                     key,
-		hg:                      hg.NewHashgraph(peers, store, commitCh, logEntry),
+		hg:                      hg.NewHashgraph(peers, store, commitCallback, logEntry),
 		peers:                   peers,
 		transactionPool:         [][]byte{},
 		internalTransactionPool: []hg.InternalTransaction{},
@@ -57,6 +57,7 @@ func NewCore(
 		Head:                    "",
 		Seq:                     -1,
 	}
+
 	return core
 }
 


### PR DESCRIPTION
Until now, committing a block to the application was an asynchronous
operation (with respect to the hashgraph). This was not a very good
idea, so we replaced it with a synchronous callback mechanism. The
hashgraph is now able to process the Commit response, which will be
useful in validating InternalTransactions before applying them.