### PR TITLE
Force babble.initKey to error when no priv_key or wrong permissions

### DIFF
--- a/src/babble/babble.go
+++ b/src/babble/babble.go
@@ -181,22 +181,8 @@ func (b *Babble) initKey() error {
 		simpleKeyfile := keys.NewSimpleKeyfile(b.Config.Keyfile())
 
 		privKey, err := simpleKeyfile.ReadKey()
-
 		if err != nil {
-			b.Config.Logger.Warn(fmt.Sprintf("Cannot read private key from file: %v", err))
-
-			privKey, err = keys.GenerateECDSAKey()
-			if err != nil {
-				b.Config.Logger.Error("Error generating a new ECDSA key")
-				return err
-			}
-
-			if err := simpleKeyfile.WriteKey(privKey); err != nil {
-				b.Config.Logger.Error("Error saving private key", err)
-				return err
-			}
-
-			b.Config.Logger.Debug("Generated a new private key")
+			b.Config.Logger.Errorf("Error reading private key from file: %v", err)
 		}
 
 		b.Config.Key = privKey

--- a/src/crypto/keys/key_reader_writer.go
+++ b/src/crypto/keys/key_reader_writer.go
@@ -3,6 +3,7 @@ package keys
 import (
 	"crypto/ecdsa"
 	"encoding/hex"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -10,20 +11,20 @@ import (
 	"sync"
 )
 
-//KeyReaderWriter reads and writes ecdsa keys from/to any format or support.
+// KeyReaderWriter reads and writes ecdsa keys from/to any format or support.
 type KeyReaderWriter interface {
 	ReadKey() (ecdsa.PrivateKey, error)
 	WriteKey(ecdsa.PrivateKey, error)
 }
 
-//SimpleKeyfile implements KeyReaderWriter with unencrypted and unformated
-//files.
+// SimpleKeyfile implements KeyReaderWriter with unencrypted and unformated
+// files.
 type SimpleKeyfile struct {
 	l       sync.Mutex
 	keyfile string
 }
 
-//NewSimpleKeyfile instantiates a new SimpleKeyfile with an underlying file
+// NewSimpleKeyfile instantiates a new SimpleKeyfile with an underlying file
 func NewSimpleKeyfile(keyfile string) *SimpleKeyfile {
 	simpleKeyfile := &SimpleKeyfile{
 		keyfile: keyfile,
@@ -32,12 +33,39 @@ func NewSimpleKeyfile(keyfile string) *SimpleKeyfile {
 	return simpleKeyfile
 }
 
-//ReadKey implements KeyReaderWriter. It reads from the underlying file which is
-//expected to contain a raw hex dump of the key's D value (big.Int), as produced
-//by WriteKey.
+// CheckFileInfo verifies that the file exists and has user permissions only.
+func (k *SimpleKeyfile) CheckFileInfo() error {
+	info, err := os.Stat(k.keyfile)
+	if err != nil {
+		return err
+	}
+
+	// get file permissions
+	perm := info.Mode().Perm()
+
+	// build 000111111 mask
+	var nonUserMask os.FileMode = (1 << 6) - 1
+
+	// get permissions for 'groups' and 'others'
+	nonUserPerm := perm & nonUserMask
+
+	if nonUserPerm != 0 {
+		return fmt.Errorf("priv_key file permissions should exclude 'groups' and 'others'. Got %o", perm)
+	}
+
+	return nil
+}
+
+// ReadKey implements KeyReaderWriter. It reads from the underlying file which
+// expected to contain a raw hex dump of the key's D value (big.Int), as
+// produced by WriteKey.
 func (k *SimpleKeyfile) ReadKey() (*ecdsa.PrivateKey, error) {
 	k.l.Lock()
 	defer k.l.Unlock()
+
+	if err := k.CheckFileInfo(); err != nil {
+		return nil, err
+	}
 
 	buf, err := ioutil.ReadFile(k.keyfile)
 	if err != nil {
@@ -54,8 +82,8 @@ func (k *SimpleKeyfile) ReadKey() (*ecdsa.PrivateKey, error) {
 	return ParsePrivateKey(key)
 }
 
-//WriteKey implements KeyReaderWriter. It writes a raw hex dump of the key's D
-//value (big.Int) to the underlying file.
+// WriteKey implements KeyReaderWriter. It writes a raw hex dump of the key's D
+// value (big.Int) to the underlying file.
 func (k *SimpleKeyfile) WriteKey(key *ecdsa.PrivateKey) error {
 	k.l.Lock()
 	defer k.l.Unlock()


### PR DESCRIPTION
The initKey function used to automatically generate a new key when
a priv_key file was not found. We decided that it would be better
to avoid this behaviour, and expect the user to generate a key
before running Babble; like ssh. In fact we also took inspiration
from ssh to check that the key file has user-only permissions.