### PR TITLE
Refactor of bombardAndWait

### DIFF
--- a/src/node/node_dyn_test.go
+++ b/src/node/node_dyn_test.go
@@ -26,7 +26,7 @@ func TestMonologue(t *testing.T) {
 	//defer drawGraphs(nodes, t)
 
 	target := 50
-	err := gossip(nodes, target, true, 3*time.Second)
+	err := gossip(nodes, target, true)
 	if err != nil {
 		t.Fatalf("Fatal Error: %v", err)
 	}
@@ -45,7 +45,7 @@ func TestJoinRequest(t *testing.T) {
 	//defer drawGraphs(nodes, t)
 
 	target := 30
-	err := gossip(nodes, target, false, 3*time.Second)
+	err := gossip(nodes, target, false)
 	if err != nil {
 		t.Fatalf("Fatal Error: %v", err)
 	}
@@ -68,7 +68,7 @@ func TestJoinRequest(t *testing.T) {
 
 	//Gossip some more
 	secondTarget := target + 30
-	err = bombardAndWait(nodes, secondTarget, 6*time.Second)
+	err = bombardAndWait(nodes, secondTarget)
 	if err != nil {
 		t.Fatalf("Fatal Error: %v", err)
 	}
@@ -89,7 +89,7 @@ func TestLeaveRequest(t *testing.T) {
 	//defer drawGraphs(nodes, t)
 
 	target := 30
-	err := gossip(nodes, target, false, 3*time.Second)
+	err := gossip(nodes, target, false)
 	if err != nil {
 		t.Fatalf("Fatal Error: %v", err)
 	}
@@ -104,7 +104,7 @@ func TestLeaveRequest(t *testing.T) {
 
 	//Gossip some more
 	secondTarget := target + 50
-	err = bombardAndWait(nodes[:3], secondTarget, 6*time.Second)
+	err = bombardAndWait(nodes[:3], secondTarget)
 	if err != nil {
 		t.Fatalf("Fatal Error: %v", err)
 	}
@@ -124,7 +124,7 @@ func TestJoinFull(t *testing.T) {
 		defer shutdownNodes(initialNodes)
 
 		target := 30
-		err := gossip(initialNodes, target, false, 6*time.Second)
+		err := gossip(initialNodes, target, false)
 		if err != nil {
 			t.Fatalf("Fatal Error: %v", err)
 		}
@@ -148,7 +148,7 @@ func TestJoinFull(t *testing.T) {
 
 		//Gossip some more
 		secondTarget := target + 50
-		err = bombardAndWait(nodes, secondTarget, 10*time.Second)
+		err = bombardAndWait(nodes, secondTarget)
 		if err != nil {
 			t.Fatalf("Fatal Error: %v", err)
 		}
@@ -182,7 +182,7 @@ func TestRejoin(t *testing.T) {
 
 		// Start 2 nodes and let them create some blocks
 		target := 50
-		err := gossip(nodes, target, false, 3*time.Second)
+		err := gossip(nodes, target, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -196,7 +196,7 @@ func TestRejoin(t *testing.T) {
 		}
 
 		// Let node1 create more blocks alone
-		err = bombardAndWait(nodes[:1], 2*target, 6*time.Second)
+		err = bombardAndWait(nodes[:1], 2*target)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -207,7 +207,7 @@ func TestRejoin(t *testing.T) {
 		nodes[1].RunAsync(true)
 
 		// Let both nodes create more blocks
-		err = bombardAndWait(nodes, 3*target, 20*time.Second)
+		err = bombardAndWait(nodes, 3*target)
 		if err != nil {
 			t.Fatalf("ERR: %s", err)
 		}

--- a/src/node/node_extra_test.go
+++ b/src/node/node_extra_test.go
@@ -38,7 +38,7 @@ func TestJoinLateExtra(t *testing.T) {
 	defer shutdownNodes(initialNodes)
 
 	target := 100
-	err := gossip(initialNodes, target, false, 10*time.Second)
+	err := gossip(initialNodes, target, false)
 	if err != nil {
 		t.Fatalf("Fatal Error: %v", err)
 	}
@@ -62,7 +62,7 @@ func TestJoinLateExtra(t *testing.T) {
 
 	//Gossip some more
 	secondTarget := target + 50
-	err = bombardAndWait(nodes, secondTarget, 20*time.Second)
+	err = bombardAndWait(nodes, secondTarget)
 	if err != nil {
 		t.Fatalf("Fatal Error: %v", err)
 	}
@@ -105,7 +105,7 @@ func TestSuccessiveJoinRequestExtra(t *testing.T) {
 		nodes = append(nodes, newNode)
 
 		//Gossip some more
-		err := bombardAndWait(nodes, target, 20*time.Second)
+		err := bombardAndWait(nodes, target)
 		if err != nil {
 			t.Error("Fatal Error in TestSuccessiveJoinRequestExtra", err)
 			t.Fatal(err)
@@ -135,7 +135,7 @@ func TestSuccessiveLeaveRequestExtra(t *testing.T) {
 		t.Logf("SUCCESSIVE LEAVE n=%d", n)
 		//defer drawGraphs(nodes, t)
 		target += 10
-		err := gossip(nodes, target, false, 4*time.Second)
+		err := gossip(nodes, target, false)
 		if err != nil {
 			t.Error("Fatal Error", err)
 			t.Fatal(err)
@@ -158,7 +158,7 @@ func TestSuccessiveLeaveRequestExtra(t *testing.T) {
 
 		//Gossip some more
 		target += 10
-		err = bombardAndWait(nodes, target, 16*time.Second)
+		err = bombardAndWait(nodes, target)
 		if err != nil {
 			t.Error("Fatal Error 3", err)
 			t.Fatal(err)
@@ -183,7 +183,7 @@ func TestSimultaneousLeaveRequestExtra(t *testing.T) {
 	//defer drawGraphs(nodes, t)
 
 	target := 30
-	err := gossip(nodes, target, false, 3*time.Second)
+	err := gossip(nodes, target, false)
 	if err != nil {
 		t.Error("Fatal Error 1", err)
 		t.Fatal(err)
@@ -207,7 +207,7 @@ func TestSimultaneousLeaveRequestExtra(t *testing.T) {
 
 	//Gossip some more
 	secondTarget := target + 50
-	err = bombardAndWait(nodes[0:2], secondTarget, 16*time.Second)
+	err = bombardAndWait(nodes[0:2], secondTarget)
 	if err != nil {
 		t.Error("Fatal Error 4", err)
 		t.Fatal(err)
@@ -226,7 +226,7 @@ func TestJoinLeaveRequestExtra(t *testing.T) {
 	//defer drawGraphs(nodes, t)
 
 	target := 15
-	err := gossip(nodes, target, false, 2*time.Second)
+	err := gossip(nodes, target, false)
 	if err != nil {
 		t.Error("Fatal Error", err)
 		t.Fatal(err)
@@ -261,7 +261,7 @@ func TestJoinLeaveRequestExtra(t *testing.T) {
 
 	//Gossip some more
 	secondTarget := target + 12
-	err = bombardAndWait(nodes, secondTarget, 16*time.Second)
+	err = bombardAndWait(nodes, secondTarget)
 	if err != nil {
 		t.Error("Fatal Error 3", err)
 		t.Fatal(err)
@@ -310,7 +310,7 @@ func TestJoiningAndLeavingExtra(t *testing.T) {
 	nodes01234 := initNodes(keys[0:5], peers01234, genesisPeerSet, 10000, 400, 15, false, "inmem", 30*time.Millisecond, t)
 
 	// Step 1b - gossip and build history
-	gossipAndCheck(nodes01234, 20, 8, "Step 1b", false, t)
+	gossipAndCheck(nodes01234, 20, "Step 1b", false, t)
 	checkPeerSets(nodes01234, t)
 
 	// Step 2 - Node 4 leaves
@@ -321,7 +321,7 @@ func TestJoiningAndLeavingExtra(t *testing.T) {
 	checkPeerSets(nodes0123, t)
 
 	// Step 3 - More history
-	gossipAndCheck(nodes0123, 30, 8, "Step 3", false, t)
+	gossipAndCheck(nodes0123, 30, "Step 3", false, t)
 
 	// Step 4 Add a new validator (node 5) and sync without using fast sync
 	node5, nodes01235 := launchNodeAndGossip("Step 4 and 5", nodes0123, peerlist.Peers[5], keys[5],
@@ -357,7 +357,7 @@ func TestJoiningAndLeavingExtra(t *testing.T) {
 
 	// New nodes array without nodes 0 to 3
 	nodes5678 := nodes01235678[4:]
-	gossipAndCheck(nodes5678, 13, 8, "Step 9e", false, t)
+	gossipAndCheck(nodes5678, 13, "Step 9e", false, t)
 
 	//  Step 10 Add Node 9
 	node9, nodes56789 := launchNodeAndGossip("Step 10", nodes5678, peerlist.Peers[9], keys[9],
@@ -424,19 +424,19 @@ func launchNodeAndGossip(
 	}
 
 	time.Sleep(1 * time.Second)
-	gossipAndCheck(nodes, targetBlockInc, gossipTimeOutSeconds, msg, checkFrames, t)
+	gossipAndCheck(nodes, targetBlockInc, msg, checkFrames, t)
 
 	return node, nodes
 }
 
-func gossipAndCheck(nodes []*Node, targetBlockInc int, timeOutSeconds time.Duration, msg string, checkFrame bool,
+func gossipAndCheck(nodes []*Node, targetBlockInc int, msg string, checkFrame bool,
 	t *testing.T) {
 
 	t.Log("gossipAndCheck " + msg)
 	target := nodes[0].core.hg.Store.LastBlockIndex() + 1
 	target += targetBlockInc
 
-	err := gossip(nodes, target, false, timeOutSeconds*time.Second)
+	err := gossip(nodes, target, false)
 	if err != nil {
 		t.Log("Fatal Error "+msg, err)
 		t.Fatal(err)

--- a/src/node/node_fastsync_test.go
+++ b/src/node/node_fastsync_test.go
@@ -21,7 +21,7 @@ func TestFastForward(t *testing.T) {
 	defer shutdownNodes(nodes)
 
 	target := 20
-	err := gossip(nodes[1:], target, false, 6*time.Second)
+	err := gossip(nodes[1:], target, false)
 	if err != nil {
 		t.Error("Fatal Error", err)
 		t.Fatal(err)
@@ -71,7 +71,7 @@ func TestCatchUp(t *testing.T) {
 
 	// create 10 blocks with 3/4 nodes
 	target := 10
-	err := gossip(nodes[:3], target, false, 6*time.Second)
+	err := gossip(nodes[:3], target, false)
 	if err != nil {
 		t.Error("Fatal Error", err)
 		t.Fatal(err)
@@ -98,7 +98,7 @@ func TestCatchUp(t *testing.T) {
 
 	// Gossip some more with all nodes
 	newTarget := target + 20
-	err = bombardAndWait(nodes, newTarget, 10*time.Second)
+	err = bombardAndWait(nodes, newTarget)
 	if err != nil {
 		t.Error("Fatal Error 2", err)
 		t.Fatal(err)
@@ -121,7 +121,7 @@ func TestFastSync(t *testing.T) {
 	//defer drawGraphs(nodes, t)
 
 	target := 30
-	err := gossip(nodes, target, false, 10*time.Second)
+	err := gossip(nodes, target, false)
 	if err != nil {
 		t.Error("Fatal Error", err)
 		t.Fatal(err)
@@ -132,7 +132,7 @@ func TestFastSync(t *testing.T) {
 	node0.Shutdown()
 
 	secondTarget := target + 30
-	err = bombardAndWait(nodes[1:], secondTarget, 10*time.Second)
+	err = bombardAndWait(nodes[1:], secondTarget)
 	if err != nil {
 		t.Error("Fatal Error 2", err)
 		t.Fatal(err)
@@ -162,7 +162,7 @@ func TestFastSync(t *testing.T) {
 
 	//Gossip some more
 	thirdTarget := secondTarget + 50
-	err = bombardAndWait(nodes, thirdTarget, 10*time.Second)
+	err = bombardAndWait(nodes, thirdTarget)
 	if err != nil {
 		t.Error("Fatal Error 3", err)
 		t.Fatal(err)


### PR DESCRIPTION
Refactor of bombardAndWait to no longer rely on a timeout for all blocks but instead implement a timeout per block. This removes the need for a large timeout allowing for slowish running of all blocks.

There is a further change to either remove the timeout parameter from bombardAndWait, or convert it to a per block timeout. 