### PR TITLE
Add getPublKey function to get public key

### DIFF
--- a/src/mobile/utils.go
+++ b/src/mobile/utils.go
@@ -1,8 +1,10 @@
 package mobile
 
 import (
+	"encoding/hex"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/mosaicnetworks/babble/src/crypto/keys"
 )
@@ -20,4 +22,24 @@ func GetPrivPublKeys() string {
 	pub := keys.PublicKeyHex(&key.PublicKey)
 
 	return pub + "=!@#@!=" + priv
+}
+
+// GetPublKey generates a  public key from the given private key and returns
+// it
+func GetPublKey(privKey string) string {
+
+	trimmedKeyString := strings.TrimSpace(privKey)
+	key, err := hex.DecodeString(trimmedKeyString)
+	if err != nil {
+		return ""
+	}
+
+	privateKey, err := keys.ParsePrivateKey(key)
+	if err != nil {
+		return ""
+	}
+
+	pub := keys.PublicKeyHex(&privateKey.PublicKey)
+
+	return pub
 }


### PR DESCRIPTION
From a given private key.

When loading an archive, you need to know the current public key - and to make efforts to fix the peers files accordingly. The configuration only saves the private. By exposing this function we can read the private key, get the public key and amend the correct peers entry to match the current network details. 

It has become more key with the refactoring to use the same workflow and data structures for archive and live sessions.