### PR TITLE
fix bug #issue-829795488

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/btcsuite/btcd v0.0.0-20190523000118-16327141da8c
 	github.com/dgraph-io/badger v1.6.0
+	github.com/gogf/greuse v1.1.0
 	github.com/gammazero/nexus/v3 v3.0.0
 	github.com/jonknight73/badger v0.0.0-20200218142835-fa9c019859f6
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect

--- a/src/proxy/socket/app/socket_app_proxy_server.go
+++ b/src/proxy/socket/app/socket_app_proxy_server.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"net/rpc"
 	"net/rpc/jsonrpc"
+	"github.com/gogf/greuse"
 
 	"github.com/sirupsen/logrus"
 )
@@ -37,8 +38,10 @@ func (p *SocketAppProxyServer) register(bindAddress string) error {
 	rpcServer.RegisterName("Babble", p)
 
 	p.rpcServer = rpcServer
+	
+	//then linux and windows can reuse same port
+	l, err := greuse.Listen("tcp", bindAddress)
 
-	l, err := net.Listen("tcp", bindAddress)
 
 	if err != nil {
 		p.logger.WithField("error", err).Error("Failed to listen")

--- a/src/proxy/socket/babble/socket_babble_proxy_server.go
+++ b/src/proxy/socket/babble/socket_babble_proxy_server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mosaicnetworks/babble/src/node/state"
 	"github.com/mosaicnetworks/babble/src/proxy"
 	"github.com/sirupsen/logrus"
+	"github.com/gogf/greuse"
 )
 
 // SocketBabbleProxyServer is the server component of the BabbleProxy which
@@ -49,7 +50,8 @@ func (p *SocketBabbleProxyServer) register(bindAddress string) error {
 
 	p.rpcServer = rpcServer
 
-	l, err := net.Listen("tcp", bindAddress)
+	//then linux and windows can reuse same port
+	l, err := greuse.Listen("tcp", bindAddress)
 
 	if err != nil {
 		return err


### PR DESCRIPTION
fix bug: #149 
Socket options SO_REUSEADDR and SO_REUSEPORT are different for different operating systems and often highly confusing.

